### PR TITLE
Print error when failing to render template

### DIFF
--- a/cmd/cmd_build.go
+++ b/cmd/cmd_build.go
@@ -48,7 +48,7 @@ var buildCmd = &cobra.Command{
 			format := exports[cfgFormat]
 
 			if err != nil {
-				abort("Failed to render template: %s", file)
+				abort("Failed to render template %q: %s", file, err)
 			}
 
 			name := strings.TrimSuffix(file, path.Ext(file)) + "." + format.extension


### PR DESCRIPTION
In order to be able to debug failures.